### PR TITLE
fix: change `react-native-builder-bob` version

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "prettier": "^2.0.5",
     "react": "16.13.1",
     "react-native": "0.63.4",
-    "react-native-builder-bob": "^",
+    "react-native-builder-bob": "^0.23.2",
     "react-native-gesture-handler": "2.3.0",
     "react-native-reanimated": "^3.2.0",
     "react-native-redash": "^16.0.8",


### PR DESCRIPTION
After cloning this library, I've stuck with the wrong dependency version. This PR fixed it