### PR TITLE
fix: moving images is incorrect

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,7 +126,8 @@
           "trailingComma": "es5",
           "useTabs": false
         }
-      ]
+      ],
+      "eslint-comments/no-unlimited-disable": "off"
     }
   },
   "eslintIgnore": [

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -26,8 +26,12 @@ import Animated, {
 } from 'react-native-reanimated';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import { useVector } from 'react-native-redash';
-import { clamp, withDecaySpring, withRubberBandClamp } from './utils';
-import { resizeImage } from './utils/image';
+import {
+  clamp,
+  withDecaySpring,
+  withRubberBandClamp,
+  resizeImage,
+} from './utils';
 
 const rtl = I18nManager.isRTL;
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -27,6 +27,7 @@ import Animated, {
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import { useVector } from 'react-native-redash';
 import { clamp, withDecaySpring, withRubberBandClamp } from './utils';
+import { resizeImage } from './utils/image';
 
 const rtl = I18nManager.isRTL;
 
@@ -367,30 +368,15 @@ const ResizableImage = React.memo(
       originalLayout.x.value = w;
       originalLayout.y.value = h;
 
-      const portrait = width > height;
-
-      if (portrait) {
-        const imageHeight = Math.min((h * width) / w, height);
-        const imageWidth = Math.min(w, width);
-        layout.y.value = imageHeight;
-        if (imageHeight === height) {
-          layout.x.value = (w * height) / h;
-        } else {
-          layout.x.value = imageWidth;
-        }
-      } else {
-        const imageWidth = Math.min((w * height) / h, width);
-        const imageHeight = Math.min(h, height);
-        layout.x.value = imageWidth;
-        if (imageWidth === width) {
-          layout.y.value = (h * width) / w;
-        } else {
-          layout.y.value = imageHeight;
-        }
-      }
+      const imgLayout = resizeImage({ width: w, height: h }, { width, height });
+      layout.x.value = imgLayout.width;
+      layout.y.value = imgLayout.height;
     };
 
     useEffect(() => {
+      if (originalLayout.x.value === 0 && originalLayout.y.value === 0) {
+        return;
+      }
       setImageDimensions({
         width: originalLayout.x.value,
         height: originalLayout.y.value,

--- a/src/utils/__tests__/image.test.ts
+++ b/src/utils/__tests__/image.test.ts
@@ -1,0 +1,81 @@
+import { resizeImage } from '../image';
+
+type Size = [number, number]; // [width, height]
+
+describe('image', () => {
+  /* eslint-disable */
+  const testData: {
+    container: Size;
+    items: [Size, Size][] // [imageSize, expectingSize]
+  }[] = [
+    {
+      container: [100, 100],
+      items: [
+        [[100, 100],  [100, 100]],
+        [[50, 50],    [100, 100]],
+        [[150, 150],  [100, 100]],
+
+        [[100, 200],  [50, 100]],
+        [[200, 100],  [100, 50]],
+
+        [[25, 50],    [50, 100]],
+        [[50, 25],    [100, 50]],
+
+        [[25, 500],   [5, 100]],
+        [[500, 25],   [100, 5]],
+      ]
+    },
+    {
+      container: [10, 100],
+      items: [
+        [[1, 1],        [10, 10]],
+        [[1000, 1000],  [10, 10]],
+
+        [[1, 2],        [10, 20]],
+        [[2, 1],        [10, 5]],
+
+        [[500, 1000],   [10, 20]],
+        [[1000, 500],   [10, 5]],
+      ]
+    },
+    {
+      container: [100, 10],
+      items: [
+        [[1, 1],        [10, 10]],
+        [[1000, 1000],  [10, 10]],
+
+        [[2, 1],        [20, 10]],
+        [[1, 2],        [5, 10]],
+
+        [[1000, 500],   [20, 10]],
+        [[500, 1000],   [5, 10]],
+      ]
+    }
+  ];
+  /* eslint-enable */
+
+  describe('resizeImage', () => {
+    testData.forEach(({ container, items }) => {
+      const [containerWidth, containerHeight] = container;
+
+      describe(`container ${containerWidth}x${containerHeight}`, () => {
+        items.forEach(([image, expecting]) => {
+          const [imageWidth, imageHeight] = image;
+          const [expectedWidth, expectedHeight] = expecting;
+          const toObj = (size: Size) => ({ width: size[0], height: size[1] });
+
+          test(
+            `image ${imageWidth}x${imageHeight} -> ` +
+              `expected ${expectedWidth}x${expectedHeight}`,
+            () => {
+              const imgSize = toObj(image);
+              const containerSize = toObj(container);
+              const expectSize = toObj(expecting);
+              expect(resizeImage(imgSize, containerSize)).toEqual(expectSize);
+            }
+          );
+        });
+      });
+    });
+  });
+});

--- a/src/utils/image.ts
+++ b/src/utils/image.ts
@@ -1,0 +1,25 @@
+type Size = { width: number; height: number };
+
+/**
+ * calculates the size of the image, how it would stretch to the borders of the container,
+ * while maintaining its proportions (Image -> resizeMode="contain")
+ */
+export const resizeImage = (
+  { width: imgWidth, height: imgHeight }: Size, // original image size
+  { width, height }: Size // target image size
+): Size => {
+  const rw = imgWidth / width;
+  const rh = imgHeight / height;
+
+  if (rw > rh) {
+    return {
+      width: width,
+      height: imgHeight / rw,
+    };
+  } else {
+    return {
+      width: imgWidth / rh,
+      height: height,
+    };
+  }
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,2 +1,3 @@
 export * from './clamping';
 export * from './withDecaySpring';
+export * from './image';


### PR DESCRIPTION
Hi, Pavel!

Thank you for the wonderful library and for making a useful contribution to OpenSource!

We have integrated this library into our application, it works quite well, but there were some problems when viewing the image.

This is due to an incorrect size setting for the image. There are 2 cases:

1. Undetermined order of calling the `setImageDimensions` function from `useEffect` and `onLoad`

We may have a situation where `onLoad` was called faster than `useEffect` when initializing the component. In this case, `useEffect` sets the width and height values to 0. This leads to a problem when the user cannot move the image when zooming in.

This is due to the library's `react-native-reanimated' feature.

In the JS stream, the values from the useSharedValue are updated asynchronously, for example:

```typescript
const sharedValue = useSharedValue(0)
sharedValue.value = 1;
console.log(sharedValue.value) // 0
```

2. Incorrect calculation of the size of the image relative to the container into which it is moved.

Example: A 200x300 picture on an iPhone 15. Gallery is displayed in full screen


https://github.com/pavelbabenko/react-native-awesome-gallery/assets/30261345/d873caa9-dc13-47c2-9bb2-62308b720a3a

If you have any questions, ask!)